### PR TITLE
feat(voice): 画面共有機能とクリック拡大表示機能を追加

### DIFF
--- a/src/components/voice/VoiceCall.tsx
+++ b/src/components/voice/VoiceCall.tsx
@@ -581,20 +581,27 @@ const ScreenShareTile = memo(function ScreenShareTile({
   trackRef,
   onClick,
 }: ScreenShareTileProps) {
+  const participantName = trackRef.participant.identity.split("-")[0];
+
   return (
-    <div
-      className="aspect-video bg-black rounded-xl border border-gray-700 overflow-hidden shadow-lg cursor-pointer hover:ring-2 hover:ring-blue-500 transition-all relative group"
+    <button
+      type="button"
+      className="aspect-video bg-black rounded-xl border border-gray-700 overflow-hidden shadow-lg cursor-pointer hover:ring-2 hover:ring-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all relative group w-full"
       onClick={() => onClick(trackRef)}
+      aria-label={`${participantName}の画面共有を拡大表示`}
     >
-      <VideoTrack trackRef={trackRef} className="w-full h-full object-cover" />
-      <div className="absolute top-2 left-2 bg-black/60 text-white text-xs px-2 py-1 rounded backdrop-blur-sm flex items-center">
+      <VideoTrack
+        trackRef={trackRef}
+        className="w-full h-full object-cover pointer-events-none"
+      />
+      <div className="absolute top-2 left-2 bg-black/60 text-white text-xs px-2 py-1 rounded backdrop-blur-sm flex items-center pointer-events-none">
         <Monitor className="w-3 h-3 mr-1" />
-        {trackRef.participant.identity.split("-")[0]} の画面
+        {participantName} の画面
       </div>
-      <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 flex items-center justify-center transition-colors">
+      <div className="absolute inset-0 bg-black/0 group-hover:bg-black/20 flex items-center justify-center transition-colors pointer-events-none">
         <Maximize2 className="text-white opacity-0 group-hover:opacity-100 transition-opacity" />
       </div>
-    </div>
+    </button>
   );
 });
 
@@ -769,10 +776,15 @@ const ParticipantTileWrapper = memo(function ParticipantTileWrapper({
   const participant = useParticipantContext();
   if (!participant) return null;
 
+  const displayName =
+    participant.identity.split("-")[0] || participant.identity;
+
   return (
     <button
-      className="aspect-square w-full h-full cursor-pointer hover:ring-2 hover:ring-green-500 rounded-xl transition-all relative group"
+      type="button"
+      className="aspect-square w-full h-full cursor-pointer hover:ring-2 hover:ring-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 rounded-xl transition-all relative group"
       onClick={() => onClick(participant)}
+      aria-label={`${displayName}のアバターを拡大表示`}
     >
       <ParticipantTile
         localRotations={localRotations}


### PR DESCRIPTION
## 概要
LiveKitを使用した画面共有機能と、参加者または画面共有をクリックして拡大表示する機能を実装しました。

## 変更内容
- 画面共有ボタン（`ScreenShareButton`）を追加
- 画面共有トラックの表示タイル（`ScreenShareTile`）を実装
- 参加者と画面共有のクリック拡大表示機能を追加
- グリッドレイアウトを統合し、画面共有と参加者を同じグリッドに表示
- フォーカスモードで拡大表示と最小化をサポート
- `ParticipantTileWrapper`でクリックイベントを処理

## 関連Issue
Closes #87

## テスト
- [x] 画面共有ボタンが正しく動作することを確認
- [x] 画面共有トラックが正しく表示されることを確認
- [x] 参加者タイルをクリックして拡大表示できることを確認
- [x] 画面共有タイルをクリックして拡大表示できることを確認
- [x] フォーカスモードから通常モードに戻れることを確認

## スクリーンショット（該当する場合）
<!-- 実装後に追加予定 -->
<img width="1710" height="906" alt="image" src="https://github.com/user-attachments/assets/679a55cb-3850-4124-a818-0d3bc680230d" />
共有画面クリック後
<img width="914" height="905" alt="image" src="https://github.com/user-attachments/assets/dd0b000f-5e1e-4716-a235-89d9b8bbc6cb" />


## チェックリスト
- [x] ブランチは最新のmain/developから作成されている
- [x] コンフリクトが解決されている
- [x] CIが通っている
- [x] 必要なドキュメントが更新されている

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * スクリーン共有を追加：開始/停止ボタンを統合し、共有映像がグリッド内のタイルとして表示されます。
  * 統合グリッド表示：参加者タイルと画面共有タイルを同一グリッドで扱い、クリックで拡大・縮小する集中表示をサポート。
* **UI強化**
  * 共有状態の視覚反映とライブ状態同期で操作感を改善し、コントロール面に画面共有ボタンを統合。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->