### PR TITLE
feat(avatar): 3Dアバター表示の品質向上と表情機能の実装

### DIFF
--- a/src/app/debug/network-sync/page.tsx
+++ b/src/app/debug/network-sync/page.tsx
@@ -13,7 +13,7 @@ import { app } from "@/lib/firebaseConfig";
 import { AvatarSender } from "@/components/avatar/AvatarSender";
 import { AvatarReceiver } from "@/components/avatar/AvatarReceiver";
 import { Button } from "@/components/ui";
-import { BoneRotations } from "@/types/avatar";
+import { AvatarMotionState } from "@/types/avatar";
 
 export default function NetworkSyncDebugPage() {
   const [token, setToken] = useState("");
@@ -211,10 +211,8 @@ export default function NetworkSyncDebugPage() {
 
 function DebugContent() {
   const participants = useParticipants();
-  const [localRotations, setLocalRotations] = useState<{
-    bones: BoneRotations;
-    blendShapes: Record<string, number>;
-  } | null>(null); // State for local preview
+  const [localRotations, setLocalRotations] =
+    useState<AvatarMotionState | null>(null); // State for local preview
 
   // ...
 
@@ -253,10 +251,7 @@ function DebugContent() {
 function ParticipantWrapper({
   localRotations,
 }: {
-  localRotations?: {
-    bones: BoneRotations;
-    blendShapes: Record<string, number>;
-  } | null;
+  localRotations?: AvatarMotionState | null;
 }) {
   const p = useParticipantContext();
 
@@ -284,10 +279,7 @@ const DebugAvatarCanvasWrapper = ({
   manualRotations,
 }: {
   participant: Participant;
-  manualRotations?: {
-    bones: BoneRotations;
-    blendShapes: Record<string, number>;
-  } | null;
+  manualRotations?: AvatarMotionState | null;
 }) => {
   return (
     <>
@@ -316,10 +308,7 @@ const DebugAvatar = ({
 }: {
   participant: Participant;
   defaultAvatarUrl: string;
-  manualRotations?: {
-    bones: BoneRotations;
-    blendShapes: Record<string, number>;
-  } | null;
+  manualRotations?: AvatarMotionState | null;
 }) => {
   return (
     <AvatarReceiver

--- a/src/app/debug/network-sync/page.tsx
+++ b/src/app/debug/network-sync/page.tsx
@@ -211,9 +211,10 @@ export default function NetworkSyncDebugPage() {
 
 function DebugContent() {
   const participants = useParticipants();
-  const [localRotations, setLocalRotations] = useState<BoneRotations | null>(
-    null
-  ); // State for local preview
+  const [localRotations, setLocalRotations] = useState<{
+    bones: BoneRotations;
+    blendShapes: Record<string, number>;
+  } | null>(null); // State for local preview
 
   // ...
 
@@ -252,7 +253,10 @@ function DebugContent() {
 function ParticipantWrapper({
   localRotations,
 }: {
-  localRotations?: BoneRotations | null;
+  localRotations?: {
+    bones: BoneRotations;
+    blendShapes: Record<string, number>;
+  } | null;
 }) {
   const p = useParticipantContext();
 
@@ -280,7 +284,10 @@ const DebugAvatarCanvasWrapper = ({
   manualRotations,
 }: {
   participant: Participant;
-  manualRotations?: BoneRotations | null;
+  manualRotations?: {
+    bones: BoneRotations;
+    blendShapes: Record<string, number>;
+  } | null;
 }) => {
   return (
     <>
@@ -309,13 +316,17 @@ const DebugAvatar = ({
 }: {
   participant: Participant;
   defaultAvatarUrl: string;
-  manualRotations?: BoneRotations | null;
+  manualRotations?: {
+    bones: BoneRotations;
+    blendShapes: Record<string, number>;
+  } | null;
 }) => {
   return (
     <AvatarReceiver
       participant={participant}
       defaultAvatarUrl={defaultAvatarUrl}
-      manualRotations={manualRotations}
+      manualRotations={manualRotations?.bones}
+      manualBlendShapes={manualRotations?.blendShapes}
     />
   );
 };

--- a/src/components/voice/VoiceCall.tsx
+++ b/src/components/voice/VoiceCall.tsx
@@ -45,11 +45,7 @@ import {
   AvatarSenderHandle,
 } from "@/components/avatar/AvatarSender";
 import { AvatarReceiver } from "@/components/avatar/AvatarReceiver";
-import {
-  BoneRotations,
-  AvatarMetadata,
-  AvatarMotionState,
-} from "@/types/avatar";
+import { AvatarMetadata, AvatarMotionState } from "@/types/avatar";
 import { Canvas, useThree } from "@react-three/fiber";
 import { useVModel } from "@/contexts/VModelContext";
 import { ensureVRMInStorage } from "@/lib/vrmStorage";

--- a/src/components/voice/VoiceCall.tsx
+++ b/src/components/voice/VoiceCall.tsx
@@ -492,7 +492,10 @@ function DeviceSettings({
 
 // 参加者個別のタイルコンポーネント
 interface ParticipantTileProps {
-  localRotations?: BoneRotations | null;
+  localMotionData?: {
+    bones: BoneRotations;
+    blendShapes: Record<string, number>;
+  } | null;
   cameraConfig: [number, number, number];
   myAvatarOffset?: { x: number; y: number; z: number };
   myAvatarScale?: number;
@@ -500,7 +503,7 @@ interface ParticipantTileProps {
 }
 
 const ParticipantTile = memo(function ParticipantTile({
-  localRotations,
+  localMotionData,
   cameraConfig,
   myAvatarOffset,
   myAvatarScale,
@@ -580,8 +583,13 @@ const ParticipantTile = memo(function ParticipantTile({
 
   const isMicrophoneEnabled = participant.isMicrophoneEnabled;
 
-  // 自分の場合のみ、ローカルの回転情報を渡す
-  const manualRotations = participant.isLocal ? localRotations : undefined;
+  // 自分の場合のみ、ローカルの回転情報と表情データを渡す
+  const manualRotations =
+    participant.isLocal && localMotionData ? localMotionData.bones : undefined;
+  const manualBlendShapes =
+    participant.isLocal && localMotionData
+      ? localMotionData.blendShapes
+      : undefined;
 
   // 自分の場合で、かつモデルを選択している場合は、デフォルトモデルを表示せず、メタデータ（動的URL）が設定されるのを待つ
   const defaultUrl =
@@ -599,15 +607,43 @@ const ParticipantTile = memo(function ParticipantTile({
         } bg-gray-900`}
       >
         {/* 3Dアバター表示 */}
-        <Canvas>
+        <Canvas
+          camera={{
+            fov: 50,
+          }}
+          gl={{
+            antialias: true,
+            powerPreference: "high-performance",
+            alpha: false,
+          }}
+          dpr={
+            typeof window !== "undefined" && window.devicePixelRatio > 2
+              ? 2
+              : typeof window !== "undefined"
+                ? window.devicePixelRatio
+                : 1
+          }
+        >
           <CameraUpdater position={cameraConfig} />
+
+          {/* 環境光（全体を明るく） */}
           <ambientLight intensity={0.8} />
-          <directionalLight position={[0, 0, 5]} intensity={1} />
+
+          {/* メインの方向光（正面やや上から） */}
+          <directionalLight position={[5, 5, 5]} intensity={1.2} />
+
+          {/* 補助ライト（左側から） */}
+          <directionalLight position={[-3, 3, 2]} intensity={0.5} />
+
+          {/* 補助ライト（後ろから、リムライト効果） */}
+          <directionalLight position={[0, 3, -5]} intensity={0.3} />
+
           {/* <OrbitControls target={[0, 1.4, 0]} /> 安定した表示のためOrbitControlsは無効化（必要に応じて有効化） */}
           <AvatarReceiver
             participant={participant}
             defaultAvatarUrl={defaultUrl}
             manualRotations={manualRotations}
+            manualBlendShapes={manualBlendShapes}
             // 自分の場合はローカルの設定を即時反映し、他人の場合はMetadataから読み取る
             localOverrideOffset={
               participant.isLocal ? myAvatarOffset : undefined
@@ -728,7 +764,10 @@ const ScreenShareTile = memo(function ScreenShareTile({
 
 // 参加者グリッド表示コンポーネント (Unified Grid & Click-to-Expand)
 interface ParticipantGridProps {
-  localRotations?: BoneRotations | null;
+  localMotionData?: {
+    bones: BoneRotations;
+    blendShapes: Record<string, number>;
+  } | null;
   cameraConfig: [number, number, number];
   myAvatarOffset: { x: number; y: number; z: number };
   myAvatarScale: number;
@@ -736,7 +775,7 @@ interface ParticipantGridProps {
 }
 
 function ParticipantGrid({
-  localRotations,
+  localMotionData,
   cameraConfig,
   myAvatarOffset,
   myAvatarScale,
@@ -806,7 +845,7 @@ function ParticipantGrid({
                  */}
               <ParticipantLoop participants={[focusedParticipant]}>
                 <ParticipantTile
-                  localRotations={localRotations}
+                  localMotionData={localMotionData}
                   cameraConfig={cameraConfig}
                   myAvatarOffset={myAvatarOffset}
                   myAvatarScale={myAvatarScale}
@@ -857,7 +896,7 @@ function ParticipantGrid({
            */}
           <ParticipantTileWrapper
             onClick={(p) => handleFocus("participant", p)}
-            localRotations={localRotations}
+            localMotionData={localMotionData}
             cameraConfig={cameraConfig}
             myAvatarOffset={myAvatarOffset}
             myAvatarScale={myAvatarScale}
@@ -879,7 +918,10 @@ function ParticipantGrid({
 // useParticipantContextをして、自身のparticipant情報を取得し、onClickハンドラに渡す
 interface ParticipantTileWrapperProps {
   onClick: (participant: Participant) => void;
-  localRotations?: BoneRotations | null;
+  localMotionData?: {
+    bones: BoneRotations;
+    blendShapes: Record<string, number>;
+  } | null;
   cameraConfig: [number, number, number];
   myAvatarOffset: { x: number; y: number; z: number };
   myAvatarScale: number;
@@ -888,7 +930,7 @@ interface ParticipantTileWrapperProps {
 
 const ParticipantTileWrapper = memo(function ParticipantTileWrapper({
   onClick,
-  localRotations,
+  localMotionData,
   cameraConfig,
   myAvatarOffset,
   myAvatarScale,
@@ -946,7 +988,7 @@ const ParticipantTileWrapper = memo(function ParticipantTileWrapper({
       aria-label={`${displayName}のアバターを拡大表示`}
     >
       <ParticipantTile
-        localRotations={localRotations}
+        localMotionData={localMotionData}
         cameraConfig={cameraConfig}
         myAvatarOffset={myAvatarOffset}
         myAvatarScale={myAvatarScale}
@@ -1036,9 +1078,10 @@ function VoiceCallContent({ onLeave }: VoiceCallContentProps) {
   }, [room, toast]);
 
   // アバター統合の状態
-  const [localRotations, setLocalRotations] = useState<BoneRotations | null>(
-    null
-  );
+  const [localMotionData, setLocalMotionData] = useState<{
+    bones: BoneRotations;
+    blendShapes: Record<string, number>;
+  } | null>(null);
   const [isCameraOn, setIsCameraOn] = useState(true); // AvatarSenderの制御用
 
   // 3D調整の状態
@@ -1354,7 +1397,7 @@ function VoiceCallContent({ onLeave }: VoiceCallContentProps) {
         <AvatarSender
           ref={avatarSenderRef}
           autoStart={isCameraOn}
-          onRotationsUpdate={setLocalRotations}
+          onRotationsUpdate={setLocalMotionData}
           cameraId={selectedVideoDeviceId}
         />
       </div>
@@ -1362,7 +1405,7 @@ function VoiceCallContent({ onLeave }: VoiceCallContentProps) {
       {/* メインエリア：参加者グリッド */}
       <div className="flex-1 overflow-y-auto flex items-center justify-center min-h-[400px]">
         <ParticipantGrid
-          localRotations={localRotations}
+          localMotionData={localMotionData}
           cameraConfig={cameraConfig}
           myAvatarOffset={avatarOffset}
           myAvatarScale={avatarScale}

--- a/src/lib/vrm-retargeter-kalidokit.ts
+++ b/src/lib/vrm-retargeter-kalidokit.ts
@@ -671,8 +671,9 @@ export const retargetPoseToVRMWithKalidokit = (
 
 export const calculateRiggedPose = (
   landmarks: PoseLandmark[],
-  worldLandmarks: PoseLandmark[] | null = null
-): BoneRotations | null => {
+  worldLandmarks: PoseLandmark[] | null = null,
+  faceLandmarks: FaceLandmark[] | null = null
+): { bones: BoneRotations; blendShapes: Record<string, number> } | null => {
   if (landmarks.length === 0) {
     return null;
   }
@@ -794,8 +795,82 @@ export const calculateRiggedPose = (
     if (pose.RightHand) {
       rotations.rightHand = toQuaternion(pose.RightHand);
     }
+    // --- Facial Expression Calculation ---
+    const blendShapes: Record<string, number> = {};
 
-    return rotations;
+    if (faceLandmarks && faceLandmarks.length > 0) {
+      const faceRig = Kalidokit.Face.solve(faceLandmarks, {
+        runtime: "mediapipe",
+        imageSize: { width: 640, height: 480 },
+      });
+
+      if (faceRig) {
+        // Blink
+        // Kalidokit gives 0(Open) - 1(Closed) usually, but check prev logic:
+        // "blinkL = faceRig.eye.l" (0 to 1). VRM blink is 0 to 1.
+        // PREVIOUS LOGIC in retargetPoseToVRMWithKalidokit:
+        // const blinkL = faceRig.eye.l;
+        // const blinkValL = 1 - blinkL;
+        // This implies faceRig.eye.l is 1(Open) to 0(Closed)?
+        // Kalidokit docs say eye.l is "Eye openness" (1=open, 0=closed).
+        // VRM Blink is "Weight of Blink" (0=open, 1=closed).
+        // So VRM = 1 - Kalidokit.
+
+        const blinkOpenL = faceRig.eye.l || 0;
+        const blinkOpenR = faceRig.eye.r || 0;
+
+        const blinkValL = 1 - blinkOpenL;
+        const blinkValR = 1 - blinkOpenR;
+
+        // Mirroring: User Left -> Avatar Right
+        const targetRight = blinkValL;
+        const targetLeft = blinkValR;
+
+        const combinedBlink = Math.min(targetLeft, targetRight);
+        const remLeft = targetLeft - combinedBlink;
+        const remRight = targetRight - combinedBlink;
+
+        blendShapes["blink"] = combinedBlink;
+        blendShapes["blinkLeft"] = remLeft;
+        blendShapes["blinkRight"] = remRight;
+
+        // Vowels
+        const mouthShape = faceRig.mouth.shape;
+        // VRM 0.0 / 1.0 Preset Names
+        // Typical VRM uses ["aa", "ih", "ou", "ee", "oh"] or ["A", "I", "U", "E", "O"]
+        // Let's use standard Preset names. V-Chat seems to use standard VRM.
+        // Previous logic: vrm.expressionManager.setValue("aa", ...);
+        blendShapes["aa"] = mouthShape.A || 0;
+        blendShapes["ih"] = mouthShape.I || 0;
+        blendShapes["ou"] = mouthShape.U || 0;
+        blendShapes["ee"] = mouthShape.E || 0;
+        blendShapes["oh"] = mouthShape.O || 0;
+
+        // Joy
+        // Logic from retargetPoseToVRMWithKalidokit
+        let browL = 0;
+        let browR = 0;
+        if (faceRig.brow) {
+          if (typeof faceRig.brow === "number") {
+            browL = browR = faceRig.brow;
+          } else {
+            browL = (faceRig.brow as { l?: number; r?: number }).l || 0;
+            browR = (faceRig.brow as { l?: number; r?: number }).r || 0;
+          }
+        }
+        const browAvg = (browL + browR) / 2;
+        const mouthX = faceRig.mouth.x || 0;
+        // smileFactor = Math.max(0, (mouthX - 0.2) * 3);
+        const smileFactor = Math.max(0, (mouthX - 0.2) * 3);
+        const joyValue = Math.min(1, smileFactor + browAvg);
+
+        blendShapes["Joy"] = joyValue;
+
+        // Angry = 0 per previous logic
+      }
+    }
+
+    return { bones: rotations, blendShapes };
   } catch (error) {
     console.error("❌ Error calculating rigged pose:", error);
     return null;

--- a/src/types/avatar.ts
+++ b/src/types/avatar.ts
@@ -33,6 +33,11 @@ export interface BoneRotations {
   rightFoot?: QuaternionArray;
 }
 
+export interface AvatarMotionState {
+  bones: BoneRotations;
+  blendShapes?: Record<string, number>;
+}
+
 export interface MotionDataPacket {
   t: "m"; // タイプ: モーション
   b?: Record<string, number>; // ブレンドシェイプ（表情）


### PR DESCRIPTION
## 概要
vrm-motion-demoを参考に、room内で表示される3Dモデルの表示品質を大幅に改善し、目ぱち・口ぱちなどの表情機能を実装しました。

## 主な変更内容

### 1. Canvas設定の最適化
- **FOV**: 50に設定（より自然な視野角）
- **アンチエイリアス**: 有効化（エッジのギザギザを滑らかに）
- **パフォーマンス**: `powerPreference: "high-performance"`で高性能モードに設定
- **DPR**: デバイスのピクセル比に応じた最適化（最大2倍まで）

### 2. ライティングの大幅改善
従来の1つの方向光から、**4つのライト**による立体的な照明に改善：
- 環境光（全体を明るく）: intensity 0.8
- メインの方向光（正面やや上から）: position [5,5,5], intensity 1.2
- 補助ライト（左側から）: position [-3,3,2], intensity 0.5
- 補助ライト（後ろから、リムライト効果）: position [0,3,-5], intensity 0.3

### 3. 表情機能の実装
- **目ぱち**（まばたき）: Kalidokitによる目の開閉検出
- **口ぱち**（リップシンク）: 母音（あいうえお）の認識と口の開閉
- **表情**: Joy（笑顔）などの表情認識
- **データ送信**: ローカルおよびネットワーク経由での表情データの送受信に対応

## 実装の詳細

### ファイル別の変更
- `AvatarReceiver.tsx`: 表情データ（ブレンドシェイプ）の受信・適用機能を追加
- `AvatarSender.tsx`: 表情データの送信機能を追加
- `VoiceCall.tsx`: Canvas設定の最適化とライティング改善、表情データの受け渡し処理
- `vrm-retargeter-kalidokit.ts`: 表情データ（目ぱち・口ぱち）の計算ロジックを追加
- `avatar.ts`: 型定義の追加
- `debug/network-sync/page.tsx`: 型定義の更新（デバッグページ）

### データフロー
1. **AvatarSender** が `calculateRiggedPose()` でボーン回転と表情データ（blendShapes）を計算
2. **VoiceCall** が `localMotionData` として受け取る
3. **AvatarReceiver** が VRM の `expressionManager` に適用
   - まばたき（Blink, BlinkLeft, BlinkRight）
   - リップシンク（aa, ih, ou, ee, oh）
   - その他の表情（Joy）

## 効果
- **より立体的な表示**: 複数の方向から光が当たることで、3Dモデルの凹凸や立体感が明確に
- **より美しい表示**: アンチエイリアスにより滑らかな輪郭
- **最適化されたパフォーマンス**: 高DPIディスプレイでも適切に動作
- **リアルな表情**: カメラからの表情がリアルタイムで3Dアバターに反映

## テスト
- 型チェック: ✅ 通過
- ESLint: ✅ 通過
- Prettier: ✅ 通過

## スクリーンショット
（実際の動作確認をお願いします）

## 関連Issue
Closes #133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * アバターの顔表現（まばたき・口・表情）が骨の動きとともにリアルタイムでキャプチャ・同期されるようになりました。
  * ローカル／ネットワーク双方で顔の動き（ブレンドシェイプ）を滑らかに補間して適用します。
  * 通話画面や参加者タイル、3Dキャンバスなどで顔表現データが一貫して伝搬されます。
  * ポーズ推定が顔ランドマークを活用し、表情データを生成します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->